### PR TITLE
feat: 소식 단일 페이지 만들기

### DIFF
--- a/apps/website/src/hooks/useNews.ts
+++ b/apps/website/src/hooks/useNews.ts
@@ -1,11 +1,11 @@
 import { useState, useEffect } from 'react';
 import { getNews, getNewsById } from '@/services/news';
-import { NewsGETResponse, NewsIdGETResponse, newsData } from '@/models/news';
+import { NewsGETResponse, NewsIdGETResponse, newsData, newsListData } from '@/models/news';
 import { handleApiError } from '@/utils/handleApiError';
 
 /** 소식 목록 불러오기 */
 export const useNewsList = () => {
-  const [data, setData] = useState<newsData[]>([]);
+  const [data, setData] = useState<newsListData[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<Error | null>(null);
 

--- a/apps/website/src/layouts/DetailLayout/DetailLayout.styled.ts
+++ b/apps/website/src/layouts/DetailLayout/DetailLayout.styled.ts
@@ -1,10 +1,16 @@
 import styled from "styled-components";
 
-export const DetailCard = styled.div`
+interface LayoutProps {
+  $isMobile?: boolean;
+  $isTablet?: boolean;
+  $isDesktop?: boolean;
+}
+
+export const DetailCard = styled.div<LayoutProps>`
   display: flex;
   width: 100%;
   max-width: 1000px;
-  padding: 50px;
+  padding: ${({ $isMobile }) => ($isMobile ? "20px": "50px")};
   flex-direction: column;
   justify-content: flex-end;
   align-items: center;
@@ -12,44 +18,45 @@ export const DetailCard = styled.div`
   border-radius: 20px;
   background: var(--FarmSystem_White, #FCFCFC);
   box-shadow: 0px 0px 20px 5px var(--FarmSystem_LightGrey, #E5E5E5);
-  gap: 70px;
+  gap: ${({ $isMobile }) => ($isMobile ? "20px": "70px")};
 `;
 
-export const GoBackContainer = styled.div`
+export const GoBackContainer = styled.div<LayoutProps>`
   display: flex;
   align-items: left;
   align-self: stretch;
 `;
 
-export const GoBackButton = styled.button`
+export const GoBackButton = styled.button<LayoutProps>`
   display: flex;
   align-items: center;
   align-self: stretch;
   cursor: pointer;
 
   color: var(--FarmSystem_Green01, #28723F);
-  font-size: 24px;
+  font-size: ${({ $isMobile }) => ($isMobile ? "16px": "24px")};
+
   font-style: normal;
   font-weight: 500;
   line-height: 40px; /* 166.667% */
   letter-spacing: -0.24px;
 `;
 
-export const GoBackImg = styled.img`
-  width: 30px;
-  height: 40px;
+export const GoBackImg = styled.img<LayoutProps>`
+  width: ${({ $isMobile }) => ($isMobile ? "20px": "30px")};;
+  height: ${({ $isMobile }) => ($isMobile ? "24px": "40px")};
 `;
 
-export const TitleContainer = styled.div`
+export const TitleContainer = styled.div<LayoutProps>`
   display: flex;
   max-width: 800px;
   width: 100%;
   flex-direction: column;
   align-items: flex-start;
-  gap: 30px;
+  gap: ${({ $isMobile }) => ($isMobile ? "15px": "30px")};
 `;
 
-export const DateAndTagContainer = styled.div`
+export const DateAndTagContainer = styled.div<LayoutProps>`
   display: flex;
   padding: 10px 0px;
   flex-direction: row;
@@ -60,19 +67,19 @@ export const DateAndTagContainer = styled.div`
   width: 100%;
 `;
 
-export const Date = styled.p`
+export const Date = styled.p<LayoutProps>`
   display: flex;
   color: var(--FarmSystem_Black, #191919);
-  font-size: 20px;
+  font-size: ${({ $isMobile }) => ($isMobile ? "16px": "20px")};
   font-style: normal;
   font-weight: 400;
   line-height: 30px; /* 150% */
   letter-spacing: -0.24px;
 `;
 
-export const Tag = styled.p`
+export const Tag = styled.p<LayoutProps>`
   display: flex;
-  height: 40px;
+  height: ${({ $isMobile }) => ($isMobile ? "32px": "40px")};
   padding: 5px 20px;
   justify-content: center;
   align-items: center;
@@ -82,14 +89,14 @@ export const Tag = styled.p`
 
   color: var(--FarmSystem_White, #FCFCFC);
   text-align: center;
-  font-size: 20px;
+  font-size: ${({ $isMobile }) => ($isMobile ? "16px": "20px")};
   font-style: normal;
   font-weight: 400;
   line-height: 20px; /* 100% */
   letter-spacing: -0.24px;
 `;
 
-export const Title = styled.h2`
+export const Title = styled.h2<LayoutProps>`
   display: flex;
   padding: 10px 0px;
   justify-content: start;
@@ -99,7 +106,7 @@ export const Title = styled.h2`
 
   color: var(--FarmSystem_Black, #191919);
   font-family: "Pretendard Variable";
-  font-size: 32px;
+  font-size: ${({ $isMobile }) => ($isMobile ? "24px": "32px")};
   font-style: normal;
   font-weight: 700;
   line-height: 40px; /* 125% */
@@ -109,16 +116,16 @@ export const Title = styled.h2`
   max-width: 800px;
 `;
 
-export const ImageContainer = styled.div`
+export const ImageContainer = styled.div<LayoutProps>`
   display: flex;
   width: 100%;
   align-items: center;
   justify-content: center;
 `;
 
-export const Thumbnail = styled.img`
+export const Thumbnail = styled.img<LayoutProps>`
   width: 827.92px;
-  height: 533px;
+  // height: 533px;
   flex-shrink: 0;
   aspect-ratio: 827.92/533.00;
 
@@ -127,14 +134,14 @@ export const Thumbnail = styled.img`
   background: url(<path-to-image>) lightgray 50% / cover no-repeat;
 `;
 
-export const ContentBox = styled.p`
+export const ContentBox = styled.p<LayoutProps>`
   width: 100%;
   max-width: 800px;
   white-space: pre-wrap;
 
   color: var(--FarmSystem_Black, #191919);
   font-family: "Pretendard Variable";
-  font-size: 20px;
+  font-size: ${({ $isMobile }) => ($isMobile ? "18px": "20px")};;
   font-style: normal;
   font-weight: 400;
   line-height: 30px; /* 150% */

--- a/apps/website/src/layouts/DetailLayout/DetailLayout.styled.ts
+++ b/apps/website/src/layouts/DetailLayout/DetailLayout.styled.ts
@@ -1,0 +1,142 @@
+import styled from "styled-components";
+
+export const DetailCard = styled.div`
+  display: flex;
+  width: 100%;
+  max-width: 1000px;
+  padding: 50px;
+  flex-direction: column;
+  justify-content: flex-end;
+  align-items: center;
+
+  border-radius: 20px;
+  background: var(--FarmSystem_White, #FCFCFC);
+  box-shadow: 0px 0px 20px 5px var(--FarmSystem_LightGrey, #E5E5E5);
+  gap: 70px;
+`;
+
+export const GoBackContainer = styled.div`
+  display: flex;
+  align-items: left;
+  align-self: stretch;
+`;
+
+export const GoBackButton = styled.button`
+  display: flex;
+  align-items: center;
+  align-self: stretch;
+  cursor: pointer;
+
+  color: var(--FarmSystem_Green01, #28723F);
+  font-size: 24px;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 40px; /* 166.667% */
+  letter-spacing: -0.24px;
+`;
+
+export const GoBackImg = styled.img`
+  width: 30px;
+  height: 40px;
+`;
+
+export const TitleContainer = styled.div`
+  display: flex;
+  max-width: 800px;
+  width: 100%;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 30px;
+`;
+
+export const DateAndTagContainer = styled.div`
+  display: flex;
+  padding: 10px 0px;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  flex: 1 0 0;
+  align-self: stretch;
+  width: 100%;
+`;
+
+export const Date = styled.p`
+  display: flex;
+  color: var(--FarmSystem_Black, #191919);
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 30px; /* 150% */
+  letter-spacing: -0.24px;
+`;
+
+export const Tag = styled.p`
+  display: flex;
+  height: 40px;
+  padding: 5px 20px;
+  justify-content: center;
+  align-items: center;
+
+  border-radius: 15px;
+  background: var(--FarmSystem_Green06, #006811);
+
+  color: var(--FarmSystem_White, #FCFCFC);
+  text-align: center;
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 20px; /* 100% */
+  letter-spacing: -0.24px;
+`;
+
+export const Title = styled.h2`
+  display: flex;
+  padding: 10px 0px;
+  justify-content: start;
+  align-items: center;
+  gap: 10px;
+  align-self: stretch;
+
+  color: var(--FarmSystem_Black, #191919);
+  font-family: "Pretendard Variable";
+  font-size: 32px;
+  font-style: normal;
+  font-weight: 700;
+  line-height: 40px; /* 125% */
+  letter-spacing: -0.24px;
+
+  width: 100%;
+  max-width: 800px;
+`;
+
+export const ImageContainer = styled.div`
+  display: flex;
+  width: 100%;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const Thumbnail = styled.img`
+  width: 827.92px;
+  height: 533px;
+  flex-shrink: 0;
+  aspect-ratio: 827.92/533.00;
+
+  border-top: 3px solid var(--FarmSystem_DarkGrey, #999);
+  border-bottom: 1px solid var(--FarmSystem_DarkGrey, #999);
+  background: url(<path-to-image>) lightgray 50% / cover no-repeat;
+`;
+
+export const ContentBox = styled.p`
+  width: 100%;
+  max-width: 800px;
+  white-space: pre-wrap;
+
+  color: var(--FarmSystem_Black, #191919);
+  font-family: "Pretendard Variable";
+  font-size: 20px;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 30px; /* 150% */
+  letter-spacing: -0.24px;
+`;

--- a/apps/website/src/layouts/DetailLayout/DetailLayout.tsx
+++ b/apps/website/src/layouts/DetailLayout/DetailLayout.tsx
@@ -1,5 +1,6 @@
 import * as S from "./DetailLayout.styled";
 import GoBackArrow from "@/assets/LeftArrow.png";
+import useMediaQueries from "@/hooks/useMediaQueries";
 
 interface DetailLayoutProps {
   title?: string;
@@ -18,27 +19,46 @@ export default function DetailLayout({
   thumbnailUrl = "",
   // imageUrls = [],
 }: DetailLayoutProps) {
-
+  const { isMobile, isTablet, isDesktop } = useMediaQueries();
 
   return (
-      <S.DetailCard>
-        <S.GoBackContainer>
-          <S.GoBackButton onClick={() => window.history.back()}>
-            <S.GoBackImg src={GoBackArrow} alt="Go back" />
+      <S.DetailCard $isMobile={isMobile} $isTablet={isTablet} $isDesktop={isDesktop}>
+        <S.GoBackContainer  $isMobile={isMobile} $isTablet={isTablet} $isDesktop={isDesktop}>
+          <S.GoBackButton 
+             $isMobile={isMobile} $isTablet={isTablet} $isDesktop={isDesktop}
+            onClick={() => window.history.back()}
+          >
+            <S.GoBackImg
+              $isMobile={isMobile} $isTablet={isTablet} $isDesktop={isDesktop} 
+              src={GoBackArrow}
+              alt="Go back"
+            />
             <p>돌아가기</p>
           </S.GoBackButton>
-        </S.GoBackContainer>
-        <S.TitleContainer>
-          <S.DateAndTagContainer>
-            <S.Date>{date}</S.Date>
-            <S.Tag>{tag}</S.Tag>
+        </S.GoBackContainer >
+        <S.TitleContainer $isMobile={isMobile} $isTablet={isTablet} $isDesktop={isDesktop}>
+          <S.DateAndTagContainer  $isMobile={isMobile} $isTablet={isTablet} $isDesktop={isDesktop}>
+            <S.Date  $isMobile={isMobile} $isTablet={isTablet} $isDesktop={isDesktop}>
+              {date}
+            </S.Date>
+            <S.Tag  $isMobile={isMobile} $isTablet={isTablet} $isDesktop={isDesktop}>
+              {tag}
+            </S.Tag>
           </S.DateAndTagContainer>
-          <S.Title>{title}</S.Title>
+          <S.Title  $isMobile={isMobile} $isTablet={isTablet} $isDesktop={isDesktop}>
+            {title}
+          </S.Title>
         </S.TitleContainer>
-        <S.ImageContainer>
-          <S.Thumbnail src={thumbnailUrl} alt={title} />
+        <S.ImageContainer  $isMobile={isMobile} $isTablet={isTablet} $isDesktop={isDesktop}>
+          <S.Thumbnail
+            $isMobile={isMobile} $isTablet={isTablet} $isDesktop={isDesktop}
+            src={thumbnailUrl}
+            alt={title}
+          />
         </S.ImageContainer>
-        <S.ContentBox>{content}</S.ContentBox>
+        <S.ContentBox  $isMobile={isMobile} $isTablet={isTablet} $isDesktop={isDesktop}>
+          {content}
+        </S.ContentBox>
       </S.DetailCard>
   );
 }

--- a/apps/website/src/layouts/DetailLayout/DetailLayout.tsx
+++ b/apps/website/src/layouts/DetailLayout/DetailLayout.tsx
@@ -1,0 +1,44 @@
+import * as S from "./DetailLayout.styled";
+import GoBackArrow from "@/assets/LeftArrow.png";
+
+interface DetailLayoutProps {
+  title?: string;
+  content?: string;
+  date?: string;
+  tag?: string;
+  thumbnailUrl?: string;
+  imageUrls?: string[];
+}
+
+export default function DetailLayout({
+  title = "(임시) 제목",
+  content = "(임시) 내용",
+  date = "(임시) 게시일자: 2025년 03월 13일",
+  tag = "(임시) 태그",
+  thumbnailUrl = "",
+  // imageUrls = [],
+}: DetailLayoutProps) {
+
+
+  return (
+      <S.DetailCard>
+        <S.GoBackContainer>
+          <S.GoBackButton onClick={() => window.history.back()}>
+            <S.GoBackImg src={GoBackArrow} alt="Go back" />
+            <p>돌아가기</p>
+          </S.GoBackButton>
+        </S.GoBackContainer>
+        <S.TitleContainer>
+          <S.DateAndTagContainer>
+            <S.Date>{date}</S.Date>
+            <S.Tag>{tag}</S.Tag>
+          </S.DateAndTagContainer>
+          <S.Title>{title}</S.Title>
+        </S.TitleContainer>
+        <S.ImageContainer>
+          <S.Thumbnail src={thumbnailUrl} alt={title} />
+        </S.ImageContainer>
+        <S.ContentBox>{content}</S.ContentBox>
+      </S.DetailCard>
+  );
+}

--- a/apps/website/src/models/news.ts
+++ b/apps/website/src/models/news.ts
@@ -10,7 +10,10 @@ export interface newsListData {
   newsId: number;
   title: string;
   thumbnailUrl: string;
-  content: string;
+  contentPreview: string;
+  tags: string[];
+  createdAt: string;
+  updatedAt: string;
 }
 
 // 단일 뉴스 데이터
@@ -20,6 +23,9 @@ export interface newsData {
   thumbnailUrl: string;
   content: string;
   imageUrls: string[];
+  tags: string[];
+  createdAt: string;
+  updatedAt: string;
 };
 
 // /api/news

--- a/apps/website/src/models/news.ts
+++ b/apps/website/src/models/news.ts
@@ -6,14 +6,24 @@ interface ApiResponse<T = unknown> {
   data?: T
 }
 
+export interface newsListData {
+  newsId: number;
+  title: string;
+  thumbnailUrl: string;
+  content: string;
+}
+
+// 단일 뉴스 데이터
 export interface newsData {
   newsId: number;
   title: string;
+  thumbnailUrl: string;
   content: string;
+  imageUrls: string[];
 };
 
 // /api/news
-export type NewsGETResponse = ApiResponse<newsData[]>;
+export type NewsGETResponse = ApiResponse<newsListData[]>;
 export type NewsIdGETResponse = ApiResponse<newsData>;
 
 // /api/admin/news

--- a/apps/website/src/pages/News/NewsDetail/index.styled.ts
+++ b/apps/website/src/pages/News/NewsDetail/index.styled.ts
@@ -1,7 +1,13 @@
 import styled from "styled-components";
 
-export const Container = styled.div`
-  padding: 100px 20px;
+interface LayoutProps {
+  $isMobile?: boolean;
+  $isTablet?: boolean;
+  $isDesktop?: boolean;
+}
+
+export const Container = styled.div<LayoutProps>`
+  padding: ${({ $isMobile }) => ($isMobile ? "100px 8px": "100px 20px")};
   display: flex;
   flex-direction: column;
   justify-content: start;
@@ -13,12 +19,12 @@ export const Container = styled.div`
   overflow-y: auto;
 `;
 
-export const NewsPageTitle = styled.h2`
+export const NewsPageTitle = styled.h2<LayoutProps>`
   display: flex;
   justify-content: flex-start;
   align-items: flex-start;
   color: var(--FarmSystem_Green01, #28723F);
-  font-size: 40px;
+  font-size:  ${({ $isMobile }) => ($isMobile ? "32px": "40px")};
   font-style: normal;
   font-weight: 700;
   line-height: 40px; /* 100% */
@@ -26,6 +32,6 @@ export const NewsPageTitle = styled.h2`
   padding: 10px 0;
   width: 100%;
   max-width: 1000px;
-  margin-top: 20px;
-  margin-bottom: 70px;
+  margin-top: ${({ $isMobile }) => ($isMobile ? "0": "20px")};;
+  margin-bottom: ${({ $isMobile }) => ($isMobile ? "30px": "70px")};
 `;

--- a/apps/website/src/pages/News/NewsDetail/index.styled.ts
+++ b/apps/website/src/pages/News/NewsDetail/index.styled.ts
@@ -1,7 +1,7 @@
 import styled from "styled-components";
 
 export const Container = styled.div`
-  padding: 100px 0 30px;
+  padding: 100px 20px;
   display: flex;
   flex-direction: column;
   justify-content: start;
@@ -23,118 +23,9 @@ export const NewsPageTitle = styled.h2`
   font-weight: 700;
   line-height: 40px; /* 100% */
 
-  padding: 10px 20px;
+  padding: 10px 0;
   width: 100%;
-  max-width: 1100px;
+  max-width: 1000px;
   margin-top: 20px;
   margin-bottom: 70px;
-`;
-
-export const NewsDetailCard = styled.div`
-  display: flex;
-  width: 100%;
-  max-width: 1100px;
-  padding: 50px;
-  flex-direction: column;
-  justify-content: flex-end;
-  align-items: center;
-
-  border-radius: 20px;
-  background: var(--FarmSystem_White, #FCFCFC);
-  box-shadow: 0px 0px 20px 5px var(--FarmSystem_LightGrey, #E5E5E5);
-  gap: 70px;
-`;
-
-export const GoBackContainer = styled.div`
-  display: flex;
-  align-items: left;
-  align-self: stretch;
-`;
-
-export const GoBackButton = styled.button`
-  display: flex;
-  align-items: center;
-  align-self: stretch;
-  cursor: pointer;
-
-  color: var(--FarmSystem_Green01, #28723F);
-  font-size: 24px;
-  font-style: normal;
-  font-weight: 500;
-  line-height: 40px; /* 166.667% */
-  letter-spacing: -0.24px;
-`;
-
-export const GoBackImg = styled.img`
-  width: 30px;
-  height: 40px;
-`;
-
-export const TitleContainer = styled.div`
-  display: flex;
-  max-width: 800px;
-  width: 100%;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 30px;
-`;
-
-export const DateAndTagContainer = styled.div`
-  display: flex;
-  padding: 10px 0px;
-  flex-direction: row;
-  justify-content: space-between;
-  align-items: center;
-  flex: 1 0 0;
-  align-self: stretch;
-  width: 100%;
-`;
-
-export const Date = styled.p`
-  display: flex;
-  color: var(--FarmSystem_Black, #191919);
-  font-size: 20px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 30px; /* 150% */
-  letter-spacing: -0.24px;
-`;
-
-export const Tag = styled.p`
-  display: flex;
-  height: 40px;
-  padding: 5px 20px;
-  justify-content: center;
-  align-items: center;
-
-  border-radius: 15px;
-  background: var(--FarmSystem_Green06, #006811);
-
-  color: var(--FarmSystem_White, #FCFCFC);
-  text-align: center;
-  font-size: 20px;
-  font-style: normal;
-  font-weight: 400;
-  line-height: 20px; /* 100% */
-  letter-spacing: -0.24px;
-`;
-
-export const Title = styled.h2`
-  display: flex;
-  padding: 10px 0px;
-  justify-content: start;
-  align-items: center;
-  gap: 10px;
-  align-self: stretch;
-
-  color: var(--FarmSystem_Black, #191919);
-  font-family: "Pretendard Variable";
-  font-size: 32px;
-  font-style: normal;
-  font-weight: 700;
-  line-height: 40px; /* 125% */
-  letter-spacing: -0.24px;
-
-  width: 100%;
-  max-width: 800px;
 `;

--- a/apps/website/src/pages/News/NewsDetail/index.tsx
+++ b/apps/website/src/pages/News/NewsDetail/index.tsx
@@ -4,12 +4,14 @@ import { useNewsDetail } from "@/hooks/useNews";
 import Logger from "@/utils/Logger";
 import DetailLayout from "@/layouts/DetailLayout/DetailLayout";
 import * as S from "./index.styled";
+import useMediaQueries from "@/hooks/useMediaQueries";
 // import { newsData } from '@/models/news';
 // import PlaceHolder from '@/assets/Images/news/PlaceHolder.png';
 
 export default function NewsDetail() {
   const { newsId } = useParams<{ newsId: string }>();
   const { data: newsData, loading: newsLoading, error: newsError } = useNewsDetail(Number(newsId));
+  const { isMobile, isTablet, isDesktop } = useMediaQueries();
 
   useEffect(() => {
     if (!newsId) return ;
@@ -33,8 +35,10 @@ export default function NewsDetail() {
   }
 
   return (
-    <S.Container>
-      <S.NewsPageTitle>소식</S.NewsPageTitle>
+    <S.Container $isMobile={isMobile} $isTablet={isTablet} $isDesktop={isDesktop}>
+      <S.NewsPageTitle $isMobile={isMobile} $isTablet={isTablet} $isDesktop={isDesktop}>
+        소식
+      </S.NewsPageTitle>
       <DetailLayout
         title={newsData?.title}
         content={newsData?.content}

--- a/apps/website/src/pages/News/NewsDetail/index.tsx
+++ b/apps/website/src/pages/News/NewsDetail/index.tsx
@@ -42,8 +42,8 @@ export default function NewsDetail() {
       <DetailLayout
         title={newsData?.title}
         content={newsData?.content}
-        date={"모름"} // newsData?.createdAt
-        tag={"홍보용"}  // newsData?.tag
+        date={newsData?.createdAt} 
+        tag={newsData?.tags?.join(", ") || "기타"}
         thumbnailUrl={newsData?.thumbnailUrl}
         imageUrls={newsData?.imageUrls}
       />

--- a/apps/website/src/pages/News/NewsDetail/index.tsx
+++ b/apps/website/src/pages/News/NewsDetail/index.tsx
@@ -2,8 +2,8 @@ import { useEffect } from "react";
 import { useParams } from "react-router";
 import { useNewsDetail } from "@/hooks/useNews";
 import Logger from "@/utils/Logger";
+import DetailLayout from "@/layouts/DetailLayout/DetailLayout";
 import * as S from "./index.styled";
-import GoBackArrow from "@/assets/LeftArrow.png";
 // import { newsData } from '@/models/news';
 // import PlaceHolder from '@/assets/Images/news/PlaceHolder.png';
 
@@ -35,22 +35,14 @@ export default function NewsDetail() {
   return (
     <S.Container>
       <S.NewsPageTitle>소식</S.NewsPageTitle>
-      <S.NewsDetailCard>
-        <S.GoBackContainer>
-          <S.GoBackButton onClick={() => window.history.back()}>
-            <S.GoBackImg src={GoBackArrow} alt="Go back" />
-            <p>돌아가기</p>
-          </S.GoBackButton>
-        </S.GoBackContainer>
-        <S.TitleContainer>
-          <S.DateAndTagContainer>
-            <S.Date>{/*newsData?.date*/ "(임시)게시일자:  2025년 03월 13일"}</S.Date>
-            <S.Tag>{/*newsData?.tag*/ "(임시) 홍보용"}</S.Tag>
-          </S.DateAndTagContainer>
-          <S.Title>{newsData?.title}</S.Title>
-        </S.TitleContainer>
-        <p>{newsData?.content}</p>
-      </S.NewsDetailCard>
+      <DetailLayout
+        title={newsData?.title}
+        content={newsData?.content}
+        date={"모름"} // newsData?.createdAt
+        tag={"홍보용"}  // newsData?.tag
+        thumbnailUrl={newsData?.thumbnailUrl}
+        imageUrls={newsData?.imageUrls}
+      />
     </S.Container>
   );
 }

--- a/apps/website/src/pages/News/NewsItem.styled.ts
+++ b/apps/website/src/pages/News/NewsItem.styled.ts
@@ -7,13 +7,13 @@ interface MobileProps {
 export const NewsItem = styled.button<MobileProps>`
   display: flex;
   padding: ${({ $isMobile }) => ($isMobile ? '10px 15px' : '20px 30px')};
-  align-items: flex-start;
+  align-items: center;
   gap: ${({ $isMobile }) => ($isMobile ? '15px' : '30px')};
 
-  align-self: stretch;
   border-radius: 10px;
   background: #F1F1F1;
   cursor: pointer;
+  max-width: 1000px;
 `;
 
 export const Thumbnail = styled.img<MobileProps>`
@@ -21,6 +21,8 @@ export const Thumbnail = styled.img<MobileProps>`
   height: ${({ $isMobile }) => ($isMobile ? 'auto' : '200px')};
   flex-shrink: 0;
   aspect-ratio: ${({ $isMobile }) => ($isMobile ? '16/9' : '311/200')};
+  border-radius: 10px;
+  // 피그마상 직선인거 아무거나 넣음
 `;
 
 export const NewsContent = styled.div<MobileProps>`
@@ -53,7 +55,6 @@ export const Content = styled.p<MobileProps>`
   width: 100%;
   height: ${({ $isMobile }) => ($isMobile ? 'auto' : '65px')};
   flex-shrink: 0;
-  align-self: stretch;
   text-align: start;
 
   color: var(--FarmSystem_Black, #191919);
@@ -62,6 +63,13 @@ export const Content = styled.p<MobileProps>`
   font-weight: 400;
   line-height: ${({ $isMobile }) => ($isMobile ? '18px' : '20px')};
   letter-spacing: -0.24px;
+
+  /* 3줄까지만 표시, 그 이상은 ... 처리 */
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-overflow: ellipsis;
 `;
 
 export const TagBox = styled.div<MobileProps>`

--- a/apps/website/src/pages/News/NewsItem.styled.ts
+++ b/apps/website/src/pages/News/NewsItem.styled.ts
@@ -14,6 +14,7 @@ export const NewsItem = styled.button<MobileProps>`
   background: #F1F1F1;
   cursor: pointer;
   max-width: 1000px;
+  width: 100%;
 `;
 
 export const Thumbnail = styled.img<MobileProps>`

--- a/apps/website/src/pages/News/NewsItem.tsx
+++ b/apps/website/src/pages/News/NewsItem.tsx
@@ -5,8 +5,6 @@ import Logger from '@/utils/Logger';
 import { useNavigate } from 'react-router';
 import useMediaQueries from '@/hooks/useMediaQueries';
 
-const dummyTags = ['태그1'];
-
 export default function NewsItem({ newsListData }: { newsListData?: newsListData }) {
   const navigate = useNavigate();
   const isMobile = useMediaQueries().isMobile;
@@ -18,17 +16,13 @@ export default function NewsItem({ newsListData }: { newsListData?: newsListData
   Logger.log(newsListData);
   const { 
     title = "", 
-    // content = "",
-    content = "백엔드에서데이터를안주면서디자인상에는 content, 즉 글목록이 있기에 일단 이렇게 아무 텍스트나 채워넣으렵니다. 아무래도 이걸 확인한게 좀 많이 늦은 시간이므로 일단을 이렇게 땜빵하겠습니다. 나중에 커밋로그 다른사람이 뒤져보다 발견하면 그냥 허허 하고 넘어가쇼" 
-  } = newsListData;
-  
+    tags = [],
+    contentPreview  } = newsListData;
   const thumbnailSrc = newsListData.thumbnailUrl || PlaceHolder;
-  const tags = dummyTags;
-
-  const maxLength = 200;
-  const truncatedContent = content.length > maxLength 
-    ? content.slice(0, maxLength) + '...'
-    : content;
+  const maxLength = 800;
+  const truncatedContent = contentPreview.length > maxLength 
+    ? contentPreview.slice(0, maxLength) + '...'
+    : contentPreview;
 
   return (
     <S.NewsItem 

--- a/apps/website/src/pages/News/NewsItem.tsx
+++ b/apps/website/src/pages/News/NewsItem.tsx
@@ -1,5 +1,5 @@
 import * as S from './NewsItem.styled';
-import { newsData } from '@/models/news';
+import { newsListData } from '@/models/news';
 import PlaceHolder from '@/assets/Images/news/PlaceHolder.png';
 import Logger from '@/utils/Logger';
 import { useNavigate } from 'react-router';
@@ -7,19 +7,22 @@ import useMediaQueries from '@/hooks/useMediaQueries';
 
 const dummyTags = ['태그1'];
 
-export default function NewsItem({ newsData }: { newsData?: newsData }) {
+export default function NewsItem({ newsListData }: { newsListData?: newsListData }) {
   const navigate = useNavigate();
   const isMobile = useMediaQueries().isMobile;
 
-  if (!newsData) {
+  if (!newsListData) {
     return null;
   }
 
-  Logger.log(newsData);
-  const { title = "", content = "" } = newsData;
+  Logger.log(newsListData);
+  const { 
+    title = "", 
+    // content = "",
+    content = "백엔드에서데이터를안주면서디자인상에는 content, 즉 글목록이 있기에 일단 이렇게 아무 텍스트나 채워넣으렵니다. 아무래도 이걸 확인한게 좀 많이 늦은 시간이므로 일단을 이렇게 땜빵하겠습니다. 나중에 커밋로그 다른사람이 뒤져보다 발견하면 그냥 허허 하고 넘어가쇼" 
+  } = newsListData;
   
-  // 아직 썸네일과 태그 정보가 없으므로 placeholder와 dummyTags 사용
-  const thumbnailSrc = PlaceHolder;
+  const thumbnailSrc = newsListData.thumbnailUrl || PlaceHolder;
   const tags = dummyTags;
 
   const maxLength = 200;
@@ -30,7 +33,7 @@ export default function NewsItem({ newsData }: { newsData?: newsData }) {
   return (
     <S.NewsItem 
       $isMobile={isMobile}
-      onClick={() => navigate(`/news/${newsData.newsId}`)}
+      onClick={() => navigate(`/news/${newsListData.newsId}`)}
     >
       <S.Thumbnail src={thumbnailSrc} alt={title} $isMobile={isMobile} />
       <S.NewsContent $isMobile={isMobile}>

--- a/apps/website/src/pages/News/index.styled.ts
+++ b/apps/website/src/pages/News/index.styled.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 export const Container = styled.div`
-  padding: 100px 0 30px;
+  padding: 100px 20px 30px;
   display: flex;
   flex-direction: column;
   justify-content: start;
@@ -23,9 +23,9 @@ export const NewsPageTitle = styled.h2`
   font-weight: 700;
   line-height: 40px; /* 100% */
 
-  padding: 10px 20px;
+  padding: 10px 0;
   width: 100%;
-  max-width: 1100px;
+  max-width: 1000px;
 `;
 
 export const DescriptionContainer = styled.div`

--- a/apps/website/src/pages/News/index.styled.ts
+++ b/apps/website/src/pages/News/index.styled.ts
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 export const Container = styled.div`
-  padding: 100px 20px 30px;
+  padding: 100px 20px;
   display: flex;
   flex-direction: column;
   justify-content: start;

--- a/apps/website/src/pages/News/index.tsx
+++ b/apps/website/src/pages/News/index.tsx
@@ -40,7 +40,7 @@ export default function News() {
       {newsData && newsData.length > 0 ? (
         <S.NewsContainer>
           {newsData.map((news, index) => (
-            <NewsItem key={index} newsData={news} />
+            <NewsItem key={index} newsListData={news} />
           ))}
         </S.NewsContainer>
       ) : (


### PR DESCRIPTION
## #️⃣연관된 이슈

- #137 

## 📝작업 내용

- 단일 소식 페이지 만들기
- 소식 전체 페이지 약간 반응형
- 단일 소식 페이지 레이아웃을 공통 레이아웃으로 제작 
  - `HomePage-FE/apps/website/src/layouts/DetailLayout/DetailLayout.tsx`

## ✅ 체크리스트

- [x] 기능이 정상적으로 동작하는지 확인
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성 (필요한 경우)
- [x] UI/UX 디자인 적용 확인
  - 다른 소식 이동은 아직 구현 안했습니다.

### 스크린샷 (선택)
| 데스크탑 | 모바일 |
|:---:|:---:|
| <img width="1710" alt="스크린샷 2025-05-21 오전 10 11 50" src="https://github.com/user-attachments/assets/dc9aa2fb-6219-4505-b782-124bb69fbdee" /> |  <img width="388" alt="스크린샷 2025-05-21 오전 10 12 08" src="https://github.com/user-attachments/assets/d2e2558b-1fe8-4e6a-bb15-4af281e760d5" /> | 

