### PR TITLE
[Feat] S3를 활용한 대량 게임 랜딩 페이지 퍼블리싱 수정

### DIFF
--- a/apps/farminglog/src/hooks/useTallPage.ts
+++ b/apps/farminglog/src/hooks/useTallPage.ts
@@ -1,0 +1,77 @@
+import { useEffect, useState } from "react";
+
+/**
+ * 문서 전체 높이(가 임계값을 넘는지 감지하는 훅입니다
+ * 기본 임계값 3000px이며, 리사이즈/레이아웃 변경에 반응
+ */
+export default function useTallPage(threshold: number = 3000): boolean {
+  const [isTall, setIsTall] = useState<boolean>(false);
+
+  useEffect(() => {
+    const getPageHeight = () => document.documentElement.scrollHeight;
+
+    // 동일 프레임 내 여러번 호출 방지
+    let rafId: number | null = null;
+    const evaluate = () => {
+      if (rafId != null) return;
+      rafId = window.requestAnimationFrame(() => {
+        rafId = null;
+        setIsTall(getPageHeight() > threshold);
+      });
+    };
+
+    // 최초 1회 평가
+    evaluate();
+
+    let ro: ResizeObserver | null = null;
+    let bodyRo: ResizeObserver | null = null;
+    let mo: MutationObserver | null = null;
+
+    // 레이아웃 변화에 반응함
+    if (typeof ResizeObserver !== "undefined") {
+      ro = new ResizeObserver(() => {
+        evaluate();
+      });
+      ro.observe(document.documentElement);
+
+      // body 높이 변화도 감지함
+      if (document.body) {
+        bodyRo = new ResizeObserver(() => {
+          evaluate();
+        });
+        bodyRo.observe(document.body);
+      }
+    } else {
+      // fallback 윈도우 리사이즈 시 반응함
+      window.addEventListener("resize", evaluate);
+    }
+
+    // DOM 변동에 반응함
+    if (typeof MutationObserver !== "undefined" && document.body) {
+      mo = new MutationObserver(() => {
+        evaluate();
+      });
+      mo.observe(document.body, {
+        subtree: true,
+        childList: true,
+        attributes: false,
+      });
+    }
+
+    // 추가 이벤트: 방향 전환 등
+    window.addEventListener("orientationchange", evaluate);
+
+    return () => {
+      if (ro) ro.disconnect();
+      if (bodyRo) bodyRo.disconnect();
+      if (mo) mo.disconnect();
+      else window.removeEventListener("resize", evaluate);
+      window.removeEventListener("orientationchange", evaluate);
+      if (rafId != null) cancelAnimationFrame(rafId);
+    };
+  }, [threshold]);
+
+  return isTall;
+}
+
+

--- a/apps/farminglog/src/pages/game/index.styled.ts
+++ b/apps/farminglog/src/pages/game/index.styled.ts
@@ -129,10 +129,12 @@ export const LandingHero = styled.div<{
   $bgMobile?: string;
 }>`
   width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
   height: 59760px;
 
 
-  background: ${({ $bgDesktop }) => `url(${$bgDesktop}) center / cover no-repeat`};
+  background: ${({ $bgDesktop }) => `url(${$bgDesktop}) center / contain no-repeat`};
 
 
   // 모바일에선 잘모르겠음 일단 때리쳐!
@@ -140,7 +142,7 @@ export const LandingHero = styled.div<{
     aspect-ratio: 750 / 2237;
     background-image: ${({ $bgDesktop, $bgMobile }) =>
       `url(${($bgMobile && $bgMobile.length > 0) ? $bgMobile : $bgDesktop})`};
-    background-size: cover;
+    background-size: contain;
     background-position: center;
   }
 `;

--- a/apps/farminglog/src/pages/game/index.styled.ts
+++ b/apps/farminglog/src/pages/game/index.styled.ts
@@ -128,10 +128,9 @@ export const LandingHero = styled.div<{
   $bgDesktop: string;
   $bgMobile?: string;
 }>`
-  width: 100%;
-  max-width: 1200px;
+  width: 1200px;
   margin: 0 auto;
-  height: 59760px;
+  height: 35000px;
 
 
   background: ${({ $bgDesktop }) => `url(${$bgDesktop}) center / contain no-repeat`};
@@ -149,8 +148,8 @@ export const LandingHero = styled.div<{
 
 export const UpButton = styled.div`
   position: fixed;
-  bottom: 100px;
-  right: 100px;
+  bottom: 70px;
+  right: 70px;
   width: 150px;
   height: 150px;
   border-radius: 50%;

--- a/apps/farminglog/src/pages/game/index.tsx
+++ b/apps/farminglog/src/pages/game/index.tsx
@@ -1,15 +1,18 @@
-import React, { useState } from 'react'; // useState를 import 합니다.
+import { useEffect, useRef, useState } from 'react'; // useState를 import 합니다.
 import { UnityWebGL } from '../../components/UnityWebGL';
 import useMediaQueries from "@/hooks/useMediaQueries";
+import useTallPage from "@/hooks/useTallPage";
 import { GameContainer, StartButton, StartContainer, LandingHero, UpButton, UpButtonImage } from './index.styled.ts';
 
 
 const Game: React.FC = () => {
   const [isGameStarted, setIsGameStarted] = useState(false);
-  const [isLanding, setIsLanding] = useState(true);
   const { isMobile } = useMediaQueries();
   const landingImage = 'https://farmsystem-bucket.s3.ap-northeast-2.amazonaws.com/game/DetailGameLanding.png';
   const upButtonImage = 'https://farmsystem-bucket.s3.ap-northeast-2.amazonaws.com/game/UpGameButton.png';
+  const isTallPage = useTallPage(3000);
+  const gameContainerRef = useRef<HTMLDivElement | null>(null);
+  const [isGameContainerInView, setIsGameContainerInView] = useState(false);
   const handleStartGame = () => {
     setIsGameStarted(true); 
   };
@@ -17,11 +20,31 @@ const Game: React.FC = () => {
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
+  useEffect(() => {
+    if (isMobile) return;
+    if (!gameContainerRef.current) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        setIsGameContainerInView(entry.isIntersecting);
+      },
+      {
+        root: null,
+        rootMargin: '0px',
+        threshold: 0.1,
+      }
+    );
+
+    observer.observe(gameContainerRef.current);
+    return () => observer.disconnect();
+  }, [isMobile]);
+
   return (
     <div
       style={{ backgroundColor: '#46D77C' }}
     >
-    <GameContainer>
+    <GameContainer ref={gameContainerRef}>
 
       
       {/** isGameStarted 값에 따라 조건부로 렌더링. */}
@@ -39,16 +62,15 @@ const Game: React.FC = () => {
       )}
     </GameContainer>
 
-    {!isMobile && (
+    {(!isMobile) && (
     <LandingHero
       $bgDesktop={landingImage}
       $bgMobile={landingImage}
-      onClick={() => setIsLanding(false)}
     >
     </LandingHero>
     )}
-    {( !isMobile && isLanding &&  
-    <UpButton onClick={handleScrollTop}  title="맨 위로">
+    {(!isMobile && isTallPage && !isGameContainerInView) && (
+    <UpButton onClick={handleScrollTop} title="맨 위로">
       <UpButtonImage src={upButtonImage} alt="Up Button" />
       </UpButton>)}
   


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #322

## 📝작업 내용

>1. Up 버튼 노출 로직 개선
데스크톱에서만 표시  
>2. 페이지 높이 3000px 초과 시에만 표시(useTallPage 훅)
GameContainer가 뷰포트에 보이는 동안에는 숨김(IntersectionObserver)
>3. 불필요 코드 정리  
heroRef, isHeroInView 및 관련 로직 제거
>4. 안정성/성능
다양한 환경에서 현재 뷰 사이즈 계산 가능

## ✅ 체크리스트

- [ ] 기능이 정상적으로 동작하는지 확인
- [ ] 코드 리뷰 반영
- [ ] 테스트 코드 작성 (필요한 경우)
- [ ] UI/UX 디자인 적용 확인

### 스크린샷 (선택)
